### PR TITLE
Document tools guidelines for new utilities

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,10 @@ This file tracks changes merged into `main` that are not yet included in a versi
 
 Format: `- Area: short description (commit <short-hash>)`
 
+## 2025-09-03
+
+- Docs: add tools contribution guidelines (commit c7bd2021ac).
+
 ## 2025-09-02
 
 - Gameplay: Strength is now a Rock-type move (commit c78da96b3a).

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,20 @@
+# Tools Contribution Guidelines
+
+## Build & Style
+- Build new tools through the existing makefile: run `make tools` and follow patterns in `make_tools.mk`.
+- Tool code must follow the repository's C style: tabs for indentation, `snake_case` for functions and variables, and `UPPER_SNAKE_CASE` for macros and constants.
+
+## Program Structure
+- Each tool should define an `int main(int argc, char **argv)` entry point.
+- Parse command line options using standard approaches (e.g. `getopt`), supporting `--help` for usage details.
+- Keep argument handling consistent with other tools; prefer long-form flags and clear error messages for invalid inputs.
+
+## Cross-Platform Considerations
+- Tools must compile and run on Linux, macOS, and Windows (via MinGW or compatible environments).
+- Avoid platform-specific APIs when possible; use standard C library functions or existing portability helpers.
+- For file I/O, handle paths and line endings portably (use binary mode where appropriate).
+
+## Documentation Requirements
+- Provide a brief `README.md` in each tool's directory describing its purpose, usage, and examples.
+- Whenever a new tool is added, update `UNRELEASED.md` with a summary entry referencing the commit.
+- Use `make tools` to verify successful compilation before submitting changes.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for tools directory
- note build patterns, entry points, argument parsing, cross-platform requirements
- record guideline addition in unreleased notes

## Testing
- `make tools` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b86da33fac83278fd3541b384eb4b9