### PR TITLE
docs: add test directory guidelines

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,10 @@ This file tracks changes merged into `main` that are not yet included in a versi
 
 Format: `- Area: short description (commit <short-hash>)`
 
+## 2025-09-03
+
+- Docs: document test directory guidelines (commit TBD)
+
 ## 2025-09-02
 
 - Gameplay: Strength is now a Rock-type move (commit c78da96b3a).

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,8 @@
+# Test Directory Guidelines
+
+- Tests live under `test/` and mirror the engine's module structure.
+  - Example: files in `test/battle/*` correspond to battle engine modules.
+- Name test source files with the pattern `*_test.c`.
+- Define test cases using the `TEST("Suite/Case")` macro from the in-repo test framework.
+- Run the full test suite with `make check`.
+  - Keep all test cases deterministic and isolated.


### PR DESCRIPTION
## Summary
- document test directory mirroring and naming in `test/AGENTS.md`
- note TEST("Suite/Case") macro usage and `make check` guidance

## Testing
- `make check` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b86d6fcf888327ac89a44f844ddac1