### PR TITLE
docs: add graphics asset guidelines

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,5 +6,6 @@ Format: `- Area: short description (commit <short-hash>)`
 
 ## 2025-09-02
 
+- Docs: add graphics asset guidelines (commit 39bfd2d2).
 - Gameplay: Strength is now a Rock-type move (commit c78da96b3a).
 

--- a/graphics/AGENTS.md
+++ b/graphics/AGENTS.md
@@ -1,0 +1,7 @@
+# Graphics Asset Guidelines
+
+- Source art lives here as indexed PNGs (usually 4bpp/16 colors). Store palettes separately in matching `.pal` files.
+- Edit only the `.png` and `.pal` sources. Generated files (`.4bpp`, `.gbapal`, `.lz`, etc.) are build artifacts and must not be committed.
+- After modifying graphics, run `make` to regenerate the converted assets. The build will invoke `tools/gfx` and produce raw and compressed files automatically.
+- Use lowercase `snake_case` for file and directory names. Palette files share the base name of their image (e.g., `sprite.png` and `sprite.pal`). Variants may use suffixes like `_shiny` or `_overworld`.
+- Converted `.4bpp`/`.gbapal` files are written next to the sources, and the compressed outputs end up in the `build/` tree during ROM creation.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for graphics assets
- record graphics guidelines in UNRELEASED

## Testing
- `make check` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b86d44c0588327b64caf12e65053d8